### PR TITLE
feat: Circuit Breaker 및 재시도 로직 구현

### DIFF
--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -85,9 +85,13 @@ async def health_check():
 
     required_ok = db_ok and es_ok and redis_ok
 
+    # Circuit Breaker 상태 수집
+    circuit_breakers = _collect_circuit_breaker_stats()
+
     return {
         "status": "ok" if required_ok else "degraded",
         "version": _get_version(),
+        "circuit_breakers": circuit_breakers,
         "components": {
             "database": {
                 "status": "connected" if db_ok else "disconnected",
@@ -115,6 +119,25 @@ async def health_check():
             },
         },
     }
+
+
+def _collect_circuit_breaker_stats() -> list[dict]:
+    """앱에 등록된 Circuit Breaker 상태를 수집한다."""
+    stats = []
+    try:
+        from app.main import app as main_app
+        orchestrator = getattr(main_app.state, "search_orchestrator", None)
+        if orchestrator is None:
+            return stats
+        embedder = getattr(orchestrator, "embedder", None)
+        llm = getattr(orchestrator, "llm", None)
+        if embedder and hasattr(embedder, "_circuit_breaker"):
+            stats.append(embedder._circuit_breaker.stats())
+        if llm and hasattr(llm, "_circuit_breaker"):
+            stats.append(llm._circuit_breaker.stats())
+    except Exception:
+        pass
+    return stats
 
 
 @router.get("/health/live")

--- a/backend/app/exceptions.py
+++ b/backend/app/exceptions.py
@@ -25,3 +25,8 @@ class SearchServiceError(RAGException):
 class GuardrailViolation(RAGException):
     status_code = 400
     error_code = "GUARDRAIL_VIOLATION"
+
+
+class CircuitBreakerOpenError(RAGException):
+    status_code = 503
+    error_code = "CIRCUIT_BREAKER_OPEN"

--- a/backend/app/services/embedding/openai.py
+++ b/backend/app/services/embedding/openai.py
@@ -1,8 +1,16 @@
-"""OpenAI 임베딩 프로바이더."""
-import tiktoken
-from openai import AsyncOpenAI
+"""OpenAI 임베딩 프로바이더 (재시도 + Circuit Breaker)."""
+import logging
 
-from app.exceptions import EmbeddingServiceError
+import tiktoken
+from openai import APIError, AsyncOpenAI, RateLimitError
+
+from app.exceptions import CircuitBreakerOpenError, EmbeddingServiceError
+from app.services.resilience import CircuitBreaker, with_retry
+
+logger = logging.getLogger(__name__)
+
+# 재시도 대상: Rate Limit(429), 서버 에러(500/503)
+_RETRYABLE_OPENAI = (RateLimitError, APIError)
 
 
 class OpenAIEmbedding:
@@ -12,6 +20,11 @@ class OpenAIEmbedding:
         self.client = AsyncOpenAI(api_key=api_key)
         self.model = model
         self.dimensions = dimensions
+        self._circuit_breaker = CircuitBreaker(
+            name="openai-embedding",
+            failure_threshold=5,
+            recovery_timeout=30.0,
+        )
         try:
             self._enc = tiktoken.encoding_for_model(model)
         except KeyError:
@@ -25,16 +38,49 @@ class OpenAIEmbedding:
         return self._enc.decode(tokens[:self.MAX_TOKENS])
 
     async def embed_documents(self, texts: list[str]) -> list[list[float]]:
-        try:
-            truncated = [self._truncate(t) for t in texts]
-            kwargs: dict = {"model": self.model, "input": truncated}
-            if self.dimensions:
-                kwargs["dimensions"] = self.dimensions
-            response = await self.client.embeddings.create(**kwargs)
-            return [item.embedding for item in response.data]
-        except Exception as e:
-            raise EmbeddingServiceError(f"OpenAI embedding failed: {e}") from e
+        return await self._embed_with_retry(texts)
 
     async def embed_query(self, text: str) -> list[float]:
         results = await self.embed_documents([text])
         return results[0]
+
+    async def _embed_with_retry(self, texts: list[str]) -> list[list[float]]:
+        # Circuit Breaker 사전 확인
+        if not self._circuit_breaker.allow_request():
+            raise CircuitBreakerOpenError(
+                f"Circuit Breaker [{self._circuit_breaker.name}] OPEN — "
+                f"임베딩 서비스 일시 중단"
+            )
+
+        truncated = [self._truncate(t) for t in texts]
+        kwargs: dict = {"model": self.model, "input": truncated}
+        if self.dimensions:
+            kwargs["dimensions"] = self.dimensions
+
+        last_error: Exception | None = None
+        max_retries = 3
+
+        for attempt in range(max_retries + 1):
+            try:
+                response = await self.client.embeddings.create(**kwargs)
+                self._circuit_breaker.record_success()
+                return [item.embedding for item in response.data]
+            except _RETRYABLE_OPENAI as e:
+                last_error = e
+                if attempt < max_retries:
+                    import asyncio
+                    import random
+                    delay = min(1.0 * (2 ** attempt), 30.0)
+                    jitter = delay * random.uniform(0.5, 1.0)
+                    logger.warning(
+                        "임베딩 재시도 %d/%d — %s (%.1f초 후)",
+                        attempt + 1, max_retries, str(e)[:100], jitter,
+                    )
+                    await asyncio.sleep(jitter)
+                else:
+                    self._circuit_breaker.record_failure()
+            except Exception as e:
+                self._circuit_breaker.record_failure()
+                raise EmbeddingServiceError(f"OpenAI embedding failed: {e}") from e
+
+        raise EmbeddingServiceError(f"OpenAI embedding failed after {max_retries} retries: {last_error}") from last_error

--- a/backend/app/services/generation/openai.py
+++ b/backend/app/services/generation/openai.py
@@ -1,19 +1,38 @@
-"""Step 4.8 GREEN: OpenAI LLM 프로바이더."""
+"""OpenAI LLM 프로바이더 (재시도 + Circuit Breaker)."""
 from __future__ import annotations
 
-from openai import AsyncOpenAI
+import asyncio
+import logging
+import random
 
-from app.exceptions import SearchServiceError
+from openai import APIError, APIStatusError, AsyncOpenAI, RateLimitError
+
+from app.exceptions import CircuitBreakerOpenError, SearchServiceError
+from app.services.resilience import CircuitBreaker
+
+logger = logging.getLogger(__name__)
+
+# 재시도 대상: Rate Limit(429), 서버 에러(5xx)
+_RETRYABLE_OPENAI = (RateLimitError, APIError)
+
+# 재시도 대상 HTTP 상태 코드
+_RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 529}
+
+
+def _is_retryable(e: Exception) -> bool:
+    """재시도 가능한 예외인지 판단."""
+    if isinstance(e, RateLimitError):
+        return True
+    if isinstance(e, APIStatusError):
+        return e.status_code in _RETRYABLE_STATUS_CODES
+    if isinstance(e, APIError):
+        return True
+    return False
 
 
 class OpenAILLM:
-    """OpenAI API 기반 LLM 프로바이더.
+    """OpenAI API 기반 LLM 프로바이더 (재시도 + Circuit Breaker)."""
 
-    LLMProvider Protocol을 구현하며, AsyncOpenAI 클라이언트를 사용하여
-    GPT 계열 모델로 텍스트를 생성한다.
-    """
-
-    # temperature를 지원하지 않는 모델 (기본값 1만 허용)
     _NO_TEMPERATURE_MODELS = {"gpt-5-mini", "gpt-5-nano"}
 
     def __init__(
@@ -25,20 +44,25 @@ class OpenAILLM:
         self.client = AsyncOpenAI(api_key=api_key)
         self.model = model
         self.temperature = temperature
+        self._circuit_breaker = CircuitBreaker(
+            name="openai-llm",
+            failure_threshold=5,
+            recovery_timeout=30.0,
+        )
 
     async def generate(self, prompt: str, system_prompt: str | None = None) -> str:
         """OpenAI Chat Completions API로 텍스트를 생성한다.
 
-        Args:
-            prompt: 사용자 프롬프트
-            system_prompt: 시스템 프롬프트 (선택)
-
-        Returns:
-            생성된 텍스트
-
-        Raises:
-            SearchServiceError: API 호출 실패 시
+        재시도: 최대 3회 (429, 500, 503 에러 시)
+        Circuit Breaker: 연속 5회 실패 시 30초 동안 회로 열림
         """
+        # Circuit Breaker 사전 확인
+        if not self._circuit_breaker.allow_request():
+            raise CircuitBreakerOpenError(
+                f"Circuit Breaker [{self._circuit_breaker.name}] OPEN — "
+                f"LLM 서비스 일시 중단"
+            )
+
         messages: list[dict[str, str]] = []
         if system_prompt:
             messages.append({"role": "system", "content": system_prompt})
@@ -48,10 +72,33 @@ class OpenAILLM:
         if self.model not in self._NO_TEMPERATURE_MODELS:
             kwargs["temperature"] = self.temperature
 
-        try:
-            response = await self.client.chat.completions.create(**kwargs)
-            return response.choices[0].message.content
-        except Exception as e:
-            raise SearchServiceError(
-                f"OpenAI LLM generation failed: {e}"
-            ) from e
+        last_error: Exception | None = None
+        max_retries = 3
+
+        for attempt in range(max_retries + 1):
+            try:
+                response = await self.client.chat.completions.create(**kwargs)
+                self._circuit_breaker.record_success()
+                return response.choices[0].message.content
+            except Exception as e:
+                if _is_retryable(e) and attempt < max_retries:
+                    last_error = e
+                    delay = min(1.0 * (2 ** attempt), 30.0)
+                    jitter = delay * random.uniform(0.5, 1.0)
+                    logger.warning(
+                        "LLM 재시도 %d/%d — %s (%.1f초 후)",
+                        attempt + 1, max_retries, str(e)[:100], jitter,
+                    )
+                    await asyncio.sleep(jitter)
+                elif _is_retryable(e):
+                    last_error = e
+                    self._circuit_breaker.record_failure()
+                else:
+                    self._circuit_breaker.record_failure()
+                    raise SearchServiceError(
+                        f"OpenAI LLM generation failed: {e}"
+                    ) from e
+
+        raise SearchServiceError(
+            f"OpenAI LLM generation failed after {max_retries} retries: {last_error}"
+        ) from last_error

--- a/backend/app/services/resilience.py
+++ b/backend/app/services/resilience.py
@@ -1,0 +1,165 @@
+"""Circuit Breaker + Retry 복원력 모듈.
+
+외부 서비스(OpenAI, Elasticsearch) 호출에 대한 재시도와
+Circuit Breaker 패턴을 제공한다.
+
+- 재시도: Exponential Backoff + jitter
+- Circuit Breaker: CLOSED → OPEN → HALF_OPEN → CLOSED
+"""
+from __future__ import annotations
+
+import asyncio
+import enum
+import logging
+import random
+import time
+from functools import wraps
+from typing import Any, Callable, Sequence, Type
+
+from app.exceptions import CircuitBreakerOpenError
+
+logger = logging.getLogger(__name__)
+
+
+class CircuitState(enum.Enum):
+    CLOSED = "CLOSED"
+    OPEN = "OPEN"
+    HALF_OPEN = "HALF_OPEN"
+
+
+class CircuitBreaker:
+    """Circuit Breaker 패턴 구현.
+
+    Args:
+        name: 서킷 브레이커 이름 (예: "openai", "elasticsearch")
+        failure_threshold: 연속 실패 횟수 임계값 (기본 5)
+        recovery_timeout: OPEN → HALF_OPEN 전이 대기 시간 (초, 기본 30)
+    """
+
+    def __init__(
+        self,
+        name: str = "default",
+        failure_threshold: int = 5,
+        recovery_timeout: float = 30.0,
+    ) -> None:
+        self.name = name
+        self.failure_threshold = failure_threshold
+        self.recovery_timeout = recovery_timeout
+        self.failure_count = 0
+        self._state = CircuitState.CLOSED
+        self._last_failure_time: float | None = None
+        self._half_open_allowed = False
+
+    @property
+    def state(self) -> CircuitState:
+        if self._state == CircuitState.OPEN and self._last_failure_time is not None:
+            elapsed = time.monotonic() - self._last_failure_time
+            if elapsed >= self.recovery_timeout:
+                self._state = CircuitState.HALF_OPEN
+                self._half_open_allowed = True
+        return self._state
+
+    def allow_request(self) -> bool:
+        """요청 허용 여부를 반환한다."""
+        current = self.state
+        if current == CircuitState.CLOSED:
+            return True
+        if current == CircuitState.HALF_OPEN and self._half_open_allowed:
+            self._half_open_allowed = False
+            return True
+        return False
+
+    def record_success(self) -> None:
+        """성공 기록. failure_count 초기화 및 CLOSED 전이."""
+        self.failure_count = 0
+        self._state = CircuitState.CLOSED
+        self._half_open_allowed = False
+
+    def record_failure(self) -> None:
+        """실패 기록. threshold 도달 시 OPEN 전이."""
+        self.failure_count += 1
+        self._last_failure_time = time.monotonic()
+
+        if self._state == CircuitState.HALF_OPEN:
+            # HALF_OPEN에서 실패 → 다시 OPEN
+            self._state = CircuitState.OPEN
+            logger.warning(
+                "Circuit Breaker [%s] HALF_OPEN → OPEN (복구 실패)",
+                self.name,
+            )
+        elif self.failure_count >= self.failure_threshold:
+            self._state = CircuitState.OPEN
+            logger.warning(
+                "Circuit Breaker [%s] OPEN (연속 %d회 실패)",
+                self.name, self.failure_count,
+            )
+
+    def stats(self) -> dict[str, Any]:
+        """현재 상태 통계를 반환한다."""
+        return {
+            "name": self.name,
+            "state": self.state.value,
+            "failure_count": self.failure_count,
+            "failure_threshold": self.failure_threshold,
+            "recovery_timeout": self.recovery_timeout,
+        }
+
+
+def with_retry(
+    max_retries: int = 3,
+    retryable_exceptions: tuple[Type[Exception], ...] = (Exception,),
+    base_delay: float = 1.0,
+    max_delay: float = 30.0,
+    circuit_breaker: CircuitBreaker | None = None,
+) -> Callable:
+    """비동기 함수에 Exponential Backoff + jitter 재시도를 적용하는 데코레이터.
+
+    Args:
+        max_retries: 최대 재시도 횟수 (초기 호출 미포함)
+        retryable_exceptions: 재시도 대상 예외 튜플
+        base_delay: 초기 대기 시간 (초)
+        max_delay: 최대 대기 시간 (초)
+        circuit_breaker: Circuit Breaker 연동 (선택)
+    """
+    def decorator(func: Callable) -> Callable:
+        @wraps(func)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            # Circuit Breaker 확인
+            if circuit_breaker and not circuit_breaker.allow_request():
+                raise CircuitBreakerOpenError(
+                    f"Circuit Breaker [{circuit_breaker.name}] OPEN — "
+                    f"서비스 일시 중단 ({circuit_breaker.recovery_timeout}초 후 복구 시도)"
+                )
+
+            last_exception: Exception | None = None
+            for attempt in range(max_retries + 1):
+                try:
+                    result = await func(*args, **kwargs)
+                    if circuit_breaker:
+                        circuit_breaker.record_success()
+                    return result
+                except retryable_exceptions as e:
+                    last_exception = e
+                    if attempt < max_retries:
+                        # Exponential Backoff + jitter
+                        delay = min(base_delay * (2 ** attempt), max_delay)
+                        jitter = delay * random.uniform(0.5, 1.0)
+                        logger.warning(
+                            "재시도 %d/%d — %s (%.1f초 후 재시도)",
+                            attempt + 1, max_retries,
+                            str(e)[:100], jitter,
+                        )
+                        await asyncio.sleep(jitter)
+                    else:
+                        if circuit_breaker:
+                            circuit_breaker.record_failure()
+                except Exception:
+                    # 재시도 불가능한 예외 → 즉시 전파
+                    if circuit_breaker:
+                        circuit_breaker.record_failure()
+                    raise
+
+            raise last_exception  # type: ignore[misc]
+
+        return wrapper
+    return decorator

--- a/backend/app/services/search/hybrid.py
+++ b/backend/app/services/search/hybrid.py
@@ -148,19 +148,30 @@ class HybridSearchOrchestrator:
             queries = [query]
 
         # ── 1. HyDE (선택적) — 원문 쿼리에만 적용 ──
+        # Graceful Degradation: HyDE 실패 → 원본 쿼리로 검색 계속
         search_query = query
         if settings.hyde_enabled and self.hyde.should_apply(query, "all"):
             lf_span = self._lf_span(lf_trace, "hyde")
             t0 = time.perf_counter()
-            hyde_doc = await self.hyde.generate(query)
-            search_query = hyde_doc
-            trace.append(PipelineStep(
-                name="hyde",
-                passed=True,
-                duration_ms=_elapsed_ms(t0),
-                detail={"generated_length": len(hyde_doc)},
-            ))
-            self._lf_end(lf_span, {"generated_doc": hyde_doc[:200]})
+            try:
+                hyde_doc = await self.hyde.generate(query)
+                search_query = hyde_doc
+                trace.append(PipelineStep(
+                    name="hyde",
+                    passed=True,
+                    duration_ms=_elapsed_ms(t0),
+                    detail={"generated_length": len(hyde_doc)},
+                ))
+                self._lf_end(lf_span, {"generated_doc": hyde_doc[:200]})
+            except Exception as e:
+                logger.warning("HyDE 생성 실패, 원본 쿼리로 계속: %s", e)
+                trace.append(PipelineStep(
+                    name="hyde",
+                    passed=False,
+                    duration_ms=_elapsed_ms(t0),
+                    detail={"error": str(e)[:200], "fallback": "original_query"},
+                ))
+                self._lf_end(lf_span, {"error": str(e)[:200]})
 
         # ── 2. 모드별 검색 실행 × 멀티쿼리 (병렬) ──
         mode = settings.search_mode
@@ -210,6 +221,7 @@ class HybridSearchOrchestrator:
                 ))
 
         # ── 4. 리랭킹 (선택적) — 전체 합집합에 대해 1회 ──
+        # Graceful Degradation: 리랭킹 실패 → 기본 검색 결과 반환
         if settings.reranking_enabled:
             # 리랭커 입력 후보 수 제한 (Cross-Encoder 메모리 보호)
             max_rerank_candidates = settings.reranker_top_k * 4
@@ -218,18 +230,29 @@ class HybridSearchOrchestrator:
 
             lf_span = self._lf_span(lf_trace, "reranking")
             t0 = time.perf_counter()
-            documents = await self.reranker.rerank(
-                query, documents, top_k=settings.reranker_top_k,
-                score_mode=settings.reranker_score_mode,
-                alpha=settings.reranker_alpha,
-            )
-            trace.append(PipelineStep(
-                name="reranking",
-                passed=True,
-                duration_ms=_elapsed_ms(t0),
-                results_count=len(documents),
-            ))
-            self._lf_end(lf_span, {"count": len(documents)})
+            try:
+                documents = await self.reranker.rerank(
+                    query, documents, top_k=settings.reranker_top_k,
+                    score_mode=settings.reranker_score_mode,
+                    alpha=settings.reranker_alpha,
+                )
+                trace.append(PipelineStep(
+                    name="reranking",
+                    passed=True,
+                    duration_ms=_elapsed_ms(t0),
+                    results_count=len(documents),
+                ))
+                self._lf_end(lf_span, {"count": len(documents)})
+            except Exception as e:
+                logger.warning("리랭킹 실패, 기본 검색 결과로 계속: %s", e)
+                trace.append(PipelineStep(
+                    name="reranking",
+                    passed=False,
+                    duration_ms=_elapsed_ms(t0),
+                    results_count=len(documents),
+                    detail={"error": str(e)[:200], "fallback": "basic_results"},
+                ))
+                self._lf_end(lf_span, {"error": str(e)[:200]})
 
         # ── [검색 품질 게이트] 점수 기반 품질 평가 + soft_fail 근거 추출 ──
         gate_soft_failed = False

--- a/backend/app/services/search/keyword_es.py
+++ b/backend/app/services/search/keyword_es.py
@@ -1,10 +1,19 @@
-"""Elasticsearch + Nori 기반 BM25 키워드 검색 엔진."""
+"""Elasticsearch + Nori 기반 BM25 키워드 검색 엔진 (재시도 지원)."""
 from __future__ import annotations
+
+import asyncio
+import logging
+import random
 
 import httpx
 
 from app.exceptions import SearchServiceError
 from app.models.schemas import SearchResult
+
+logger = logging.getLogger(__name__)
+
+# 재시도 대상 Elasticsearch 예외
+_RETRYABLE_ES = (httpx.ConnectError, httpx.TimeoutException, httpx.RemoteProtocolError)
 
 
 class ElasticsearchNoriEngine:
@@ -12,6 +21,8 @@ class ElasticsearchNoriEngine:
 
     Nori 형태소 분석은 인덱스 매핑 레벨에서 설정되므로,
     쿼리 시에는 단순 match 쿼리만 전송하면 된다.
+
+    재시도: 최대 3회 (연결 실패, 타임아웃 시)
     """
 
     def __init__(
@@ -39,25 +50,42 @@ class ElasticsearchNoriEngine:
             SearchResult 리스트 (score 내림차순)
 
         Raises:
-            SearchServiceError: Elasticsearch 통신 실패 시
+            SearchServiceError: 최대 재시도 후에도 실패 시
         """
         body = self._build_query(query, top_k, doc_id)
 
-        try:
-            async with httpx.AsyncClient() as client:
-                response = await client.post(
-                    f"{self.es_url}/{self.index_name}/_search",
-                    json=body,
-                    timeout=30.0,
-                )
-                response.raise_for_status()
-                data = response.json()
-        except Exception as e:
-            raise SearchServiceError(
-                f"Elasticsearch keyword search failed: {e}"
-            ) from e
+        last_error: Exception | None = None
+        max_retries = 3
 
-        return self._parse_hits(data)
+        for attempt in range(max_retries + 1):
+            try:
+                async with httpx.AsyncClient() as client:
+                    response = await client.post(
+                        f"{self.es_url}/{self.index_name}/_search",
+                        json=body,
+                        timeout=30.0,
+                    )
+                    response.raise_for_status()
+                    data = response.json()
+                return self._parse_hits(data)
+            except _RETRYABLE_ES as e:
+                last_error = e
+                if attempt < max_retries:
+                    delay = min(1.0 * (2 ** attempt), 15.0)
+                    jitter = delay * random.uniform(0.5, 1.0)
+                    logger.warning(
+                        "ES 검색 재시도 %d/%d — %s (%.1f초 후)",
+                        attempt + 1, max_retries, str(e)[:100], jitter,
+                    )
+                    await asyncio.sleep(jitter)
+            except Exception as e:
+                raise SearchServiceError(
+                    f"Elasticsearch keyword search failed: {e}"
+                ) from e
+
+        raise SearchServiceError(
+            f"Elasticsearch keyword search failed after {max_retries} retries: {last_error}"
+        ) from last_error
 
     def _build_query(
         self,

--- a/backend/app/tasks/indexing.py
+++ b/backend/app/tasks/indexing.py
@@ -1,7 +1,10 @@
-"""문서 인덱싱 비동기 태스크."""
+"""문서 인덱싱 비동기 태스크 (강화된 재시도 로직)."""
 import asyncio
+import logging
 
 from app.worker import celery_app
+
+logger = logging.getLogger(__name__)
 
 
 async def get_document_file_path(doc_id: str) -> str:
@@ -87,10 +90,27 @@ async def _run_indexing(doc_id: str):
     await processor.process(doc_id, file_path)
 
 
-@celery_app.task(bind=True, max_retries=3)
+@celery_app.task(
+    bind=True,
+    max_retries=5,
+    autoretry_for=(Exception,),
+    retry_backoff=60,
+    retry_backoff_max=600,
+    retry_jitter=True,
+)
 def index_document_task(self, doc_id: str):
-    """문서 인덱싱 비동기 태스크."""
+    """문서 인덱싱 비동기 태스크.
+
+    재시도 전략:
+    - 최대 5회 재시도 (기존 3회에서 강화)
+    - Exponential Backoff: 60초 → 120초 → 240초 → 480초 → 600초(max)
+    - jitter 추가 (thundering herd 방지)
+    """
     try:
         asyncio.run(_run_indexing(doc_id))
     except Exception as exc:
-        self.retry(exc=exc, countdown=60)
+        logger.error(
+            "문서 인덱싱 실패 (재시도 %d/%d) — doc_id=%s, error=%s",
+            self.request.retries, self.max_retries, doc_id, str(exc)[:200],
+        )
+        raise

--- a/backend/tests/unit/test_celery_tasks.py
+++ b/backend/tests/unit/test_celery_tasks.py
@@ -18,8 +18,8 @@ class TestCelerySetup:
         assert index_document_task.name is not None
 
     def test_index_task_retry_config(self):
-        """재시도 설정 확인."""
-        assert index_document_task.max_retries == 3
+        """재시도 설정 확인 (Issue #12: 3→5로 강화)."""
+        assert index_document_task.max_retries == 5
 
 
 class TestIndexDocumentTask:

--- a/backend/tests/unit/test_resilience.py
+++ b/backend/tests/unit/test_resilience.py
@@ -1,0 +1,522 @@
+"""Circuit Breaker + Retry 모듈 단위 테스트.
+
+⚡ 지훈: TDD RED → GREEN → REFACTOR
+🔒 민수: Circuit Breaker 설정값 안전성 검증
+"""
+import asyncio
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.exceptions import (
+    CircuitBreakerOpenError,
+    EmbeddingServiceError,
+    SearchServiceError,
+)
+from app.services.resilience import (
+    CircuitBreaker,
+    CircuitState,
+    with_retry,
+)
+
+# 테스트용 UUID
+_UUID1 = uuid.uuid4()
+_UUID2 = uuid.uuid4()
+
+
+# ──────────────────────────────────────────────────────
+# CircuitBreaker 단위 테스트
+# ──────────────────────────────────────────────────────
+
+class TestCircuitBreaker:
+    """Circuit Breaker 상태 전이 검증."""
+
+    def test_initial_state_is_closed(self):
+        """초기 상태는 CLOSED."""
+        cb = CircuitBreaker(failure_threshold=3, recovery_timeout=10.0)
+        assert cb.state == CircuitState.CLOSED
+
+    def test_stays_closed_on_success(self):
+        """성공 호출 시 CLOSED 유지."""
+        cb = CircuitBreaker(failure_threshold=3, recovery_timeout=10.0)
+        cb.record_success()
+        assert cb.state == CircuitState.CLOSED
+        assert cb.failure_count == 0
+
+    def test_opens_after_failure_threshold(self):
+        """연속 실패가 threshold에 도달하면 OPEN."""
+        cb = CircuitBreaker(failure_threshold=5, recovery_timeout=30.0)
+        for _ in range(5):
+            cb.record_failure()
+        assert cb.state == CircuitState.OPEN
+
+    def test_does_not_open_before_threshold(self):
+        """threshold 미만에서는 CLOSED 유지."""
+        cb = CircuitBreaker(failure_threshold=5, recovery_timeout=30.0)
+        for _ in range(4):
+            cb.record_failure()
+        assert cb.state == CircuitState.CLOSED
+
+    def test_success_resets_failure_count(self):
+        """성공 시 failure_count 초기화."""
+        cb = CircuitBreaker(failure_threshold=5, recovery_timeout=30.0)
+        cb.record_failure()
+        cb.record_failure()
+        cb.record_success()
+        assert cb.failure_count == 0
+        assert cb.state == CircuitState.CLOSED
+
+    def test_open_circuit_denies_request(self):
+        """OPEN 상태에서 allow_request()는 False."""
+        cb = CircuitBreaker(failure_threshold=3, recovery_timeout=30.0)
+        for _ in range(3):
+            cb.record_failure()
+        assert not cb.allow_request()
+
+    def test_half_open_after_recovery_timeout(self):
+        """recovery_timeout 이후 HALF_OPEN 전이."""
+        cb = CircuitBreaker(failure_threshold=3, recovery_timeout=0.1)
+        for _ in range(3):
+            cb.record_failure()
+        assert cb.state == CircuitState.OPEN
+
+        import time
+        time.sleep(0.15)
+
+        assert cb.state == CircuitState.HALF_OPEN
+        assert cb.allow_request()  # HALF_OPEN에서는 1회 허용
+
+    def test_half_open_success_closes_circuit(self):
+        """HALF_OPEN에서 성공 시 CLOSED로 전이."""
+        cb = CircuitBreaker(failure_threshold=3, recovery_timeout=0.1)
+        for _ in range(3):
+            cb.record_failure()
+
+        import time
+        time.sleep(0.15)
+
+        assert cb.state == CircuitState.HALF_OPEN
+        cb.record_success()
+        assert cb.state == CircuitState.CLOSED
+        assert cb.failure_count == 0
+
+    def test_half_open_failure_reopens_circuit(self):
+        """HALF_OPEN에서 실패 시 다시 OPEN."""
+        cb = CircuitBreaker(failure_threshold=3, recovery_timeout=0.1)
+        for _ in range(3):
+            cb.record_failure()
+
+        import time
+        time.sleep(0.15)
+
+        assert cb.state == CircuitState.HALF_OPEN
+        cb.record_failure()
+        assert cb.state == CircuitState.OPEN
+
+    def test_circuit_breaker_name(self):
+        """Circuit Breaker에 이름 설정."""
+        cb = CircuitBreaker(name="openai", failure_threshold=5, recovery_timeout=30.0)
+        assert cb.name == "openai"
+
+    def test_circuit_breaker_stats(self):
+        """통계 정보 반환."""
+        cb = CircuitBreaker(name="openai", failure_threshold=5, recovery_timeout=30.0)
+        cb.record_failure()
+        cb.record_failure()
+        stats = cb.stats()
+        assert stats["name"] == "openai"
+        assert stats["state"] == "CLOSED"
+        assert stats["failure_count"] == 2
+        assert stats["failure_threshold"] == 5
+
+
+# ──────────────────────────────────────────────────────
+# with_retry 데코레이터 테스트
+# ──────────────────────────────────────────────────────
+
+class TestWithRetry:
+    """재시도 데코레이터 검증."""
+
+    @pytest.mark.asyncio
+    async def test_succeeds_without_retry(self):
+        """정상 호출 시 재시도 없이 성공."""
+        mock_fn = AsyncMock(return_value="ok")
+
+        @with_retry(max_retries=3, retryable_exceptions=(Exception,))
+        async def call():
+            return await mock_fn()
+
+        result = await call()
+        assert result == "ok"
+        assert mock_fn.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_retries_on_retryable_exception(self):
+        """재시도 가능한 예외 시 재시도 후 성공."""
+        mock_fn = AsyncMock(
+            side_effect=[SearchServiceError("rate limit"), "ok"]
+        )
+
+        @with_retry(
+            max_retries=3,
+            retryable_exceptions=(SearchServiceError,),
+            base_delay=0.01,
+        )
+        async def call():
+            return await mock_fn()
+
+        result = await call()
+        assert result == "ok"
+        assert mock_fn.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_raises_after_max_retries(self):
+        """max_retries 초과 시 최종 예외 발생."""
+        mock_fn = AsyncMock(
+            side_effect=SearchServiceError("always fails")
+        )
+
+        @with_retry(
+            max_retries=3,
+            retryable_exceptions=(SearchServiceError,),
+            base_delay=0.01,
+        )
+        async def call():
+            return await mock_fn()
+
+        with pytest.raises(SearchServiceError, match="always fails"):
+            await call()
+        assert mock_fn.call_count == 4  # 1 initial + 3 retries
+
+    @pytest.mark.asyncio
+    async def test_no_retry_on_non_retryable_exception(self):
+        """재시도 불가능한 예외 시 즉시 발생."""
+        mock_fn = AsyncMock(
+            side_effect=ValueError("bad input")
+        )
+
+        @with_retry(
+            max_retries=3,
+            retryable_exceptions=(SearchServiceError,),
+            base_delay=0.01,
+        )
+        async def call():
+            return await mock_fn()
+
+        with pytest.raises(ValueError, match="bad input"):
+            await call()
+        assert mock_fn.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_retry_with_circuit_breaker(self):
+        """Circuit Breaker 연동 - OPEN 시 즉시 CircuitBreakerOpenError."""
+        cb = CircuitBreaker(failure_threshold=2, recovery_timeout=30.0)
+
+        @with_retry(
+            max_retries=3,
+            retryable_exceptions=(SearchServiceError,),
+            base_delay=0.01,
+            circuit_breaker=cb,
+        )
+        async def call():
+            raise SearchServiceError("fail")
+
+        # 첫 호출: 4회 (1 + 3 retries) 시도 후 실패, CB failure_count = 1
+        with pytest.raises(SearchServiceError):
+            await call()
+        assert cb.failure_count == 1
+
+        # 두 번째 호출: 재시도 후 실패, CB failure_count = 2 → OPEN
+        with pytest.raises(SearchServiceError):
+            await call()
+        assert cb.state == CircuitState.OPEN
+
+        # 세 번째 호출: CB OPEN이므로 즉시 CircuitBreakerOpenError
+        with pytest.raises(CircuitBreakerOpenError):
+            await call()
+
+
+# ──────────────────────────────────────────────────────
+# OpenAI 서비스 재시도 통합 테스트
+# ──────────────────────────────────────────────────────
+
+class TestOpenAIEmbeddingResilience:
+    """OpenAI 임베딩 서비스 재시도 + Circuit Breaker 검증."""
+
+    @pytest.mark.asyncio
+    async def test_embedding_retries_on_rate_limit(self):
+        """429 Rate Limit 시 재시도 후 성공."""
+        from openai import RateLimitError
+        from app.services.embedding.openai import OpenAIEmbedding
+
+        embedder = OpenAIEmbedding(api_key="test-key")
+
+        mock_response = AsyncMock()
+        mock_response.data = [AsyncMock(embedding=[0.1] * 1536)]
+
+        with patch.object(
+            embedder.client.embeddings, "create",
+            new_callable=AsyncMock,
+            side_effect=[
+                RateLimitError(
+                    message="Rate limit exceeded",
+                    response=AsyncMock(status_code=429, headers={}),
+                    body=None,
+                ),
+                mock_response,
+            ],
+        ):
+            result = await embedder.embed_query("테스트 쿼리")
+            assert len(result) == 1536
+
+    @pytest.mark.asyncio
+    async def test_embedding_circuit_breaker_opens(self):
+        """연속 실패 시 Circuit Breaker 열림."""
+        from openai import APIError
+        from app.services.embedding.openai import OpenAIEmbedding
+
+        embedder = OpenAIEmbedding(api_key="test-key")
+        # Circuit breaker 직접 검증
+        embedder._circuit_breaker.failure_threshold = 2
+
+        with patch.object(
+            embedder.client.embeddings, "create",
+            new_callable=AsyncMock,
+            side_effect=APIError(
+                message="Server error",
+                request=AsyncMock(),
+                body=None,
+            ),
+        ):
+            # 첫 호출: 재시도 후 실패 → CB에 실패 기록
+            for _ in range(2):
+                with pytest.raises(EmbeddingServiceError):
+                    await embedder.embed_query("test")
+
+        # CB가 열려있으므로 즉시 차단
+        with pytest.raises(CircuitBreakerOpenError):
+            await embedder.embed_query("test")
+
+
+class TestOpenAILLMResilience:
+    """OpenAI LLM 서비스 재시도 + Circuit Breaker 검증."""
+
+    @pytest.mark.asyncio
+    async def test_llm_retries_on_server_error(self):
+        """500/503 에러 시 재시도 후 성공."""
+        from openai import APIStatusError
+        from app.services.generation.openai import OpenAILLM
+
+        llm = OpenAILLM(api_key="test-key")
+
+        mock_response = AsyncMock()
+        mock_response.choices = [
+            AsyncMock(message=AsyncMock(content="답변 내용"))
+        ]
+
+        error_response = AsyncMock()
+        error_response.status_code = 503
+        error_response.headers = {}
+        error_response.json.return_value = {"error": {"message": "Overloaded"}}
+
+        with patch.object(
+            llm.client.chat.completions, "create",
+            new_callable=AsyncMock,
+            side_effect=[
+                APIStatusError(
+                    message="Service unavailable",
+                    response=error_response,
+                    body=None,
+                ),
+                mock_response,
+            ],
+        ):
+            result = await llm.generate("테스트 프롬프트")
+            assert result == "답변 내용"
+
+
+# ──────────────────────────────────────────────────────
+# Elasticsearch 재시도 테스트
+# ──────────────────────────────────────────────────────
+
+class TestElasticsearchResilience:
+    """Elasticsearch 키워드 검색 재시도 검증."""
+
+    @pytest.mark.asyncio
+    async def test_es_retries_on_connection_error(self):
+        """ES 연결 실패 시 재시도 후 성공."""
+        import httpx
+        from app.services.search.keyword_es import ElasticsearchNoriEngine
+
+        engine = ElasticsearchNoriEngine()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json = MagicMock(return_value={"hits": {"hits": []}})
+
+        with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+            mock_post.side_effect = [
+                httpx.ConnectError("Connection refused"),
+                mock_response,
+            ]
+            results = await engine.search("테스트")
+            assert results == []
+            assert mock_post.call_count == 2
+
+
+# ──────────────────────────────────────────────────────
+# Graceful Degradation 테스트
+# ──────────────────────────────────────────────────────
+
+class TestGracefulDegradation:
+    """파이프라인 단계별 실패 시 우아한 성능저하."""
+
+    @pytest.mark.asyncio
+    async def test_reranking_failure_returns_basic_results(self):
+        """리랭킹 실패 → 기본 검색 결과 반환."""
+        from app.services.search.hybrid import HybridSearchOrchestrator
+        from app.models.schemas import SearchResult
+        from app.config import RAGSettings
+
+        # Mock 설정
+        mock_embedder = AsyncMock()
+        mock_embedder.embed_query = AsyncMock(return_value=[0.1] * 1536)
+
+        mock_vector = AsyncMock()
+        mock_vector.search = AsyncMock(return_value=[
+            SearchResult(
+                chunk_id=_UUID1, document_id=_UUID2,
+                content="검색 결과", score=0.8,
+            ),
+        ])
+
+        mock_keyword = AsyncMock()
+        mock_keyword.search = AsyncMock(return_value=[])
+
+        mock_reranker = AsyncMock()
+        mock_reranker.rerank = AsyncMock(
+            side_effect=Exception("리랭커 메모리 부족")
+        )
+
+        mock_llm = AsyncMock()
+        mock_llm.generate = AsyncMock(return_value="답변")
+
+        mock_hyde = AsyncMock()
+        mock_hyde.should_apply = lambda *a: False
+
+        orchestrator = HybridSearchOrchestrator(
+            embedder=mock_embedder,
+            vector_engine=mock_vector,
+            keyword_engine=mock_keyword,
+            reranker=mock_reranker,
+            hyde_generator=mock_hyde,
+            llm=mock_llm,
+        )
+
+        settings = RAGSettings(
+            reranking_enabled=True,
+            search_mode="vector",
+        )
+
+        result = await orchestrator.search("테스트 쿼리", settings)
+
+        # 리랭킹 실패해도 기본 검색 결과로 답변 생성
+        assert len(result.documents) > 0
+        assert result.answer == "답변"
+
+        # 트레이스에서 리랭킹 실패 기록 확인
+        reranking_step = next(
+            (s for s in result.trace if s.name == "reranking"), None
+        )
+        assert reranking_step is not None
+        assert not reranking_step.passed
+
+    @pytest.mark.asyncio
+    async def test_hyde_failure_uses_original_query(self):
+        """HyDE 실패 → 원본 쿼리로 검색."""
+        from app.services.search.hybrid import HybridSearchOrchestrator
+        from app.models.schemas import SearchResult
+        from app.config import RAGSettings
+
+        mock_embedder = AsyncMock()
+        mock_embedder.embed_query = AsyncMock(return_value=[0.1] * 1536)
+
+        mock_vector = AsyncMock()
+        mock_vector.search = AsyncMock(return_value=[
+            SearchResult(
+                chunk_id=_UUID1, document_id=_UUID2,
+                content="결과", score=0.9,
+            ),
+        ])
+
+        mock_keyword = AsyncMock()
+        mock_keyword.search = AsyncMock(return_value=[])
+
+        mock_reranker = AsyncMock()
+        mock_hyde = AsyncMock()
+        mock_hyde.should_apply = lambda *a: True
+        mock_hyde.generate = AsyncMock(
+            side_effect=Exception("HyDE LLM timeout")
+        )
+
+        mock_llm = AsyncMock()
+        mock_llm.generate = AsyncMock(return_value="답변")
+
+        orchestrator = HybridSearchOrchestrator(
+            embedder=mock_embedder,
+            vector_engine=mock_vector,
+            keyword_engine=mock_keyword,
+            reranker=mock_reranker,
+            hyde_generator=mock_hyde,
+            llm=mock_llm,
+        )
+
+        settings = RAGSettings(
+            hyde_enabled=True,
+            search_mode="vector",
+            reranking_enabled=False,
+            multi_query_enabled=False,
+            retrieval_quality_gate_enabled=False,
+            injection_detection_enabled=False,
+            pii_detection_enabled=False,
+            faithfulness_enabled=False,
+            hallucination_detection_enabled=False,
+            numeric_verification_enabled=False,
+        )
+
+        result = await orchestrator.search("원본 쿼리", settings)
+
+        # HyDE 실패해도 원본 쿼리로 검색 성공
+        assert len(result.documents) > 0
+
+        # embed_query가 원본 쿼리로 호출됨
+        mock_embedder.embed_query.assert_called_with("원본 쿼리")
+
+        # 트레이스에서 HyDE 실패 기록
+        hyde_step = next(
+            (s for s in result.trace if s.name == "hyde"), None
+        )
+        assert hyde_step is not None
+        assert not hyde_step.passed
+
+    @pytest.mark.asyncio
+    async def test_langfuse_failure_continues_pipeline(self):
+        """Langfuse 실패 → 로그만 남기고 파이프라인 계속."""
+        from app.monitoring.langfuse import LangfuseMonitor
+
+        monitor = LangfuseMonitor(
+            public_key="test-pk",
+            secret_key="test-sk",
+        )
+        # 강제 활성화 후 내부 langfuse 객체에서 에러 발생
+        monitor.enabled = True
+        monitor._langfuse = AsyncMock()
+        monitor._langfuse.start_span.side_effect = Exception("Langfuse down")
+
+        # create_trace에서 예외가 발생해도 _NoOp 반환
+        result = monitor.create_trace("test-trace", "input")
+        # NoOp이므로 어떤 메서드 호출도 안전
+        result.update(output="test")
+        result.end()


### PR DESCRIPTION
## Summary

Closes #12

외부 API(OpenAI, Elasticsearch) 호출의 복원력을 강화하여 연쇄 장애를 방지하고 Graceful Degradation을 지원합니다.

- **Circuit Breaker 패턴 구현** (`app/services/resilience.py`)
  - CLOSED → OPEN(30초) → HALF_OPEN 상태 전이
  - OpenAI Embedding/LLM: 연속 5회 실패 시 회로 열림, 30초 후 복구 시도
  - Health API에서 Circuit Breaker 상태 모니터링 가능

- **Exponential Backoff 재시도 + jitter**
  - OpenAI API: 429(Rate Limit), 500, 502, 503, 529 에러 시 최대 3회 재시도
  - Elasticsearch: ConnectError, TimeoutException 시 최대 3회 재시도
  - thundering herd 방지를 위한 jitter 적용

- **Graceful Degradation**
  - 리랭킹 실패 → 기본 검색 결과로 답변 생성 (서비스 중단 없음)
  - HyDE 실패 → 원본 쿼리로 검색 계속
  - Langfuse 실패 → 로그만 남기고 파이프라인 계속 (기존 동작)

- **Celery 인덱싱 태스크 강화**
  - max_retries: 3 → 5
  - Exponential Backoff: 60초 → 120초 → 240초 → 480초 → 600초(max)
  - jitter 추가

## 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `app/services/resilience.py` | **NEW** Circuit Breaker + with_retry 데코레이터 |
| `app/exceptions.py` | CircuitBreakerOpenError 추가 |
| `app/services/embedding/openai.py` | 재시도 + Circuit Breaker 적용 |
| `app/services/generation/openai.py` | 재시도 + Circuit Breaker 적용 |
| `app/services/search/keyword_es.py` | ES 연결 재시도 적용 |
| `app/services/search/hybrid.py` | 리랭킹/HyDE Graceful Degradation |
| `app/api/health.py` | Circuit Breaker 상태 노출 |
| `app/tasks/indexing.py` | Celery 재시도 강화 (3→5, backoff) |
| `tests/unit/test_resilience.py` | **NEW** 23개 테스트 (100% 통과) |
| `tests/unit/test_celery_tasks.py` | max_retries 기대값 수정 |

## Test plan

- [x] Circuit Breaker 상태 전이 테스트 (11개)
- [x] with_retry 데코레이터 테스트 (5개)
- [x] OpenAI Embedding 재시도/CB 테스트 (2개)
- [x] OpenAI LLM 재시도 테스트 (1개)
- [x] Elasticsearch 재시도 테스트 (1개)
- [x] Graceful Degradation 테스트 (3개)
- [x] 기존 단위 테스트 494개 전체 통과
- [x] 기존 통합 resilience 테스트 8개 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)