### PR TITLE
a11y: ARIA 레이블/역할/Skip-link 및 jsx-a11y 린트 적용 (#20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ UrstoryRAG는 **한국어에 최적화된 프로덕션 레벨 RAG(Retrieval-Augm
 | **보안 헤더** | X-Content-Type-Options, X-Frame-Options, CSP 등 보안 미들웨어 |
 | **Rate Limiting** | slowapi 기반 엔드포인트별 요청 제한 (로그인 5/min, 검색 30/min) |
 | **CORS 화이트리스트** | 환경변수 기반 허용 오리진 관리 (`allow_origins=["*"]` 제거) |
+| **접근성(a11y)** | ARIA 레이블/역할, 키보드 포커스 링, Skip-link, 에러 라이브 리전 적용. `eslint-plugin-jsx-a11y` 규칙으로 CI 자동 검증 |
 
 ---
 

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -1,10 +1,29 @@
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
+import jsxA11y from "eslint-plugin-jsx-a11y";
 
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  // eslint-config-next already registers the jsx-a11y plugin.
+  // Enable the recommended rule set on top of its defaults.
+  {
+    files: ["**/*.{js,jsx,ts,tsx}"],
+    rules: {
+      ...jsxA11y.configs.recommended.rules,
+      // Korean UI: tune rules that are too strict for this project.
+      "jsx-a11y/no-autofocus": ["warn", { ignoreNonDOM: true }],
+      "jsx-a11y/label-has-associated-control": [
+        "error",
+        {
+          required: {
+            some: ["nesting", "id"],
+          },
+        },
+      ],
+    },
+  },
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.2.2",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "shadcn": "^3.8.5",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       eslint-config-next:
         specifier: 16.2.2
         version: 16.2.2(@typescript-eslint/parser@8.58.0(eslint@9.39.3(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.3(jiti@2.6.1))(typescript@6.0.2)
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.10.2
+        version: 6.10.2(eslint@9.39.3(jiti@2.6.1))
       shadcn:
         specifier: ^3.8.5
         version: 3.8.5(@types/node@24.12.2)(typescript@6.0.2)

--- a/frontend/src/app/documents/[id]/page.tsx
+++ b/frontend/src/app/documents/[id]/page.tsx
@@ -49,8 +49,8 @@ export default function DocumentDetailPage({
     <div className="space-y-6">
       <div className="flex items-center gap-3">
         <Button variant="ghost" size="icon" asChild>
-          <Link href="/documents">
-            <ArrowLeft className="h-4 w-4" />
+          <Link href="/documents" aria-label="문서 목록으로 돌아가기">
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
           </Link>
         </Button>
         <h2 className="text-2xl font-bold">문서 상세</h2>

--- a/frontend/src/app/evaluation/compare/page.tsx
+++ b/frontend/src/app/evaluation/compare/page.tsx
@@ -35,8 +35,8 @@ export default function ComparePage() {
     <div className="space-y-6">
       <div className="flex items-center gap-3">
         <Button variant="ghost" size="icon" asChild>
-          <Link href="/evaluation">
-            <ArrowLeft className="h-4 w-4" />
+          <Link href="/evaluation" aria-label="평가로 돌아가기">
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
           </Link>
         </Button>
         <h2 className="text-2xl font-bold">평가 비교</h2>

--- a/frontend/src/app/evaluation/datasets/page.tsx
+++ b/frontend/src/app/evaluation/datasets/page.tsx
@@ -53,8 +53,8 @@ export default function DatasetsPage() {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
           <Button variant="ghost" size="icon" asChild>
-            <Link href="/evaluation">
-              <ArrowLeft className="h-4 w-4" />
+            <Link href="/evaluation" aria-label="평가로 돌아가기">
+              <ArrowLeft className="h-4 w-4" aria-hidden="true" />
             </Link>
           </Button>
           <h2 className="text-2xl font-bold">평가 데이터셋</h2>

--- a/frontend/src/app/evaluation/runs/page.tsx
+++ b/frontend/src/app/evaluation/runs/page.tsx
@@ -162,8 +162,8 @@ export default function RunsPage() {
     <div className="space-y-6">
       <div className="flex items-center gap-3">
         <Button variant="ghost" size="icon" asChild>
-          <Link href="/evaluation">
-            <ArrowLeft className="h-4 w-4" />
+          <Link href="/evaluation" aria-label="평가로 돌아가기">
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
           </Link>
         </Button>
         <h2 className="text-2xl font-bold">평가 실행</h2>

--- a/frontend/src/app/global-error.tsx
+++ b/frontend/src/app/global-error.tsx
@@ -18,9 +18,9 @@ export default function GlobalError({
   }, [error]);
 
   return (
-    <html>
+    <html lang="ko">
       <body className="flex min-h-screen items-center justify-center bg-gray-50 p-4">
-        <div className="max-w-md text-center space-y-4">
+        <div className="max-w-md text-center space-y-4" role="alert">
           <h2 className="text-xl font-semibold text-gray-900">
             예상치 못한 오류가 발생했습니다
           </h2>

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth-context";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 export default function LoginPage() {
@@ -37,29 +38,44 @@ export default function LoginPage() {
           <p className="text-sm text-muted-foreground">관리자 콘솔에 로그인하세요</p>
         </CardHeader>
         <CardContent>
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div>
+          <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+            <div className="space-y-2">
+              <Label htmlFor="username">아이디</Label>
               <Input
+                id="username"
                 type="text"
                 placeholder="아이디"
                 value={username}
                 onChange={(e) => setUsername(e.target.value)}
                 required
                 autoComplete="username"
+                aria-invalid={Boolean(error) || undefined}
+                aria-describedby={error ? "login-error" : undefined}
               />
             </div>
-            <div>
+            <div className="space-y-2">
+              <Label htmlFor="password">비밀번호</Label>
               <Input
+                id="password"
                 type="password"
                 placeholder="비밀번호"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 required
                 autoComplete="current-password"
+                aria-invalid={Boolean(error) || undefined}
+                aria-describedby={error ? "login-error" : undefined}
               />
             </div>
             {error && (
-              <p className="text-sm text-destructive">{error}</p>
+              <p
+                id="login-error"
+                role="alert"
+                aria-live="assertive"
+                className="text-sm text-destructive"
+              >
+                {error}
+              </p>
             )}
             <Button type="submit" className="w-full" disabled={loading}>
               {loading ? "로그인 중..." : "로그인"}

--- a/frontend/src/app/monitoring/metrics/page.tsx
+++ b/frontend/src/app/monitoring/metrics/page.tsx
@@ -33,8 +33,8 @@ export default function MetricsPage() {
     <div className="space-y-6">
       <div className="flex items-center gap-3">
         <Button variant="ghost" size="icon" asChild>
-          <Link href="/monitoring">
-            <ArrowLeft className="h-4 w-4" />
+          <Link href="/monitoring" aria-label="모니터링으로 돌아가기">
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
           </Link>
         </Button>
         <h2 className="text-2xl font-bold">시스템 메트릭</h2>

--- a/frontend/src/app/monitoring/traces/page.tsx
+++ b/frontend/src/app/monitoring/traces/page.tsx
@@ -109,8 +109,8 @@ export default function TracesPage() {
     <div className="space-y-6">
       <div className="flex items-center gap-3">
         <Button variant="ghost" size="icon" asChild>
-          <Link href="/monitoring">
-            <ArrowLeft className="h-4 w-4" />
+          <Link href="/monitoring" aria-label="모니터링으로 돌아가기">
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
           </Link>
         </Button>
         <h2 className="text-2xl font-bold">트레이스</h2>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -41,7 +41,7 @@ export default function DashboardPage() {
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
             <CardTitle className="text-sm font-medium">총 문서</CardTitle>
-            <FileText className="h-4 w-4 text-muted-foreground" />
+            <FileText className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">
@@ -52,7 +52,7 @@ export default function DashboardPage() {
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
             <CardTitle className="text-sm font-medium">총 청크</CardTitle>
-            <Layers className="h-4 w-4 text-muted-foreground" />
+            <Layers className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">
@@ -63,7 +63,7 @@ export default function DashboardPage() {
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
             <CardTitle className="text-sm font-medium">오늘 쿼리</CardTitle>
-            <MessageSquare className="h-4 w-4 text-muted-foreground" />
+            <MessageSquare className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">
@@ -74,7 +74,7 @@ export default function DashboardPage() {
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
             <CardTitle className="text-sm font-medium">평균 응답 시간</CardTitle>
-            <Clock className="h-4 w-4 text-muted-foreground" />
+            <Clock className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">

--- a/frontend/src/app/settings/api-keys/page.tsx
+++ b/frontend/src/app/settings/api-keys/page.tsx
@@ -82,11 +82,11 @@ export default function ApiKeysPage() {
   return (
     <div className="space-y-6">
       <div className="flex items-center gap-4">
-        <Link href="/settings">
-          <Button variant="ghost" size="icon">
-            <ArrowLeft className="h-4 w-4" />
-          </Button>
-        </Link>
+        <Button variant="ghost" size="icon" asChild>
+          <Link href="/settings" aria-label="설정 목록으로 돌아가기">
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+          </Link>
+        </Button>
         <div className="flex-1">
           <h1 className="text-2xl font-bold">API Key 관리</h1>
           <p className="text-muted-foreground text-sm">
@@ -164,8 +164,9 @@ export default function ApiKeysPage() {
                             variant="ghost"
                             size="icon"
                             onClick={() => setDeleteTarget(k.id)}
+                            aria-label={`API Key "${k.name}" 폐기`}
                           >
-                            <Trash2 className="h-4 w-4 text-destructive" />
+                            <Trash2 className="h-4 w-4 text-destructive" aria-hidden="true" />
                           </Button>
                         )}
                       </td>
@@ -251,8 +252,17 @@ print(response.choices[0].message.content)`}
           <div className="space-y-4">
             <div className="bg-muted p-3 rounded-lg flex items-center gap-2">
               <code className="flex-1 text-sm break-all">{createdKey}</code>
-              <Button size="icon" variant="ghost" onClick={handleCopy}>
-                {copied ? <Check className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
+              <Button
+                size="icon"
+                variant="ghost"
+                onClick={handleCopy}
+                aria-label={copied ? "복사 완료" : "API Key 복사"}
+              >
+                {copied ? (
+                  <Check className="h-4 w-4 text-green-500" aria-hidden="true" />
+                ) : (
+                  <Copy className="h-4 w-4" aria-hidden="true" />
+                )}
               </Button>
             </div>
             <p className="text-sm text-destructive font-medium">

--- a/frontend/src/app/settings/chunking/page.tsx
+++ b/frontend/src/app/settings/chunking/page.tsx
@@ -10,8 +10,8 @@ export default function ChunkingSettingsPage() {
     <div className="space-y-6">
       <div className="flex items-center gap-3">
         <Button variant="ghost" size="icon" asChild>
-          <Link href="/settings">
-            <ArrowLeft className="h-4 w-4" />
+          <Link href="/settings" aria-label="설정 목록으로 돌아가기">
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
           </Link>
         </Button>
         <h2 className="text-2xl font-bold">청킹 설정</h2>

--- a/frontend/src/app/settings/embedding/page.tsx
+++ b/frontend/src/app/settings/embedding/page.tsx
@@ -10,8 +10,8 @@ export default function EmbeddingSettingsPage() {
     <div className="space-y-6">
       <div className="flex items-center gap-3">
         <Button variant="ghost" size="icon" asChild>
-          <Link href="/settings">
-            <ArrowLeft className="h-4 w-4" />
+          <Link href="/settings" aria-label="설정 목록으로 돌아가기">
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
           </Link>
         </Button>
         <h2 className="text-2xl font-bold">임베딩 설정</h2>

--- a/frontend/src/app/settings/generation/page.tsx
+++ b/frontend/src/app/settings/generation/page.tsx
@@ -10,8 +10,8 @@ export default function GenerationSettingsPage() {
     <div className="space-y-6">
       <div className="flex items-center gap-3">
         <Button variant="ghost" size="icon" asChild>
-          <Link href="/settings">
-            <ArrowLeft className="h-4 w-4" />
+          <Link href="/settings" aria-label="설정 목록으로 돌아가기">
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
           </Link>
         </Button>
         <h2 className="text-2xl font-bold">답변 생성 설정</h2>

--- a/frontend/src/app/settings/guardrails/page.tsx
+++ b/frontend/src/app/settings/guardrails/page.tsx
@@ -10,8 +10,8 @@ export default function GuardrailsSettingsPage() {
     <div className="space-y-6">
       <div className="flex items-center gap-3">
         <Button variant="ghost" size="icon" asChild>
-          <Link href="/settings">
-            <ArrowLeft className="h-4 w-4" />
+          <Link href="/settings" aria-label="설정 목록으로 돌아가기">
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
           </Link>
         </Button>
         <h2 className="text-2xl font-bold">가드레일 설정</h2>

--- a/frontend/src/app/settings/hyde/page.tsx
+++ b/frontend/src/app/settings/hyde/page.tsx
@@ -10,8 +10,8 @@ export default function HyDESettingsPage() {
     <div className="space-y-6">
       <div className="flex items-center gap-3">
         <Button variant="ghost" size="icon" asChild>
-          <Link href="/settings">
-            <ArrowLeft className="h-4 w-4" />
+          <Link href="/settings" aria-label="설정 목록으로 돌아가기">
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
           </Link>
         </Button>
         <h2 className="text-2xl font-bold">HyDE 설정</h2>

--- a/frontend/src/app/settings/reranking/page.tsx
+++ b/frontend/src/app/settings/reranking/page.tsx
@@ -10,8 +10,8 @@ export default function RerankingSettingsPage() {
     <div className="space-y-6">
       <div className="flex items-center gap-3">
         <Button variant="ghost" size="icon" asChild>
-          <Link href="/settings">
-            <ArrowLeft className="h-4 w-4" />
+          <Link href="/settings" aria-label="설정 목록으로 돌아가기">
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
           </Link>
         </Button>
         <h2 className="text-2xl font-bold">리랭킹 설정</h2>

--- a/frontend/src/app/settings/search/page.tsx
+++ b/frontend/src/app/settings/search/page.tsx
@@ -10,8 +10,8 @@ export default function SearchSettingsPage() {
     <div className="space-y-6">
       <div className="flex items-center gap-3">
         <Button variant="ghost" size="icon" asChild>
-          <Link href="/settings">
-            <ArrowLeft className="h-4 w-4" />
+          <Link href="/settings" aria-label="설정 목록으로 돌아가기">
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
           </Link>
         </Button>
         <h2 className="text-2xl font-bold">검색 설정</h2>

--- a/frontend/src/app/settings/users/page.tsx
+++ b/frontend/src/app/settings/users/page.tsx
@@ -175,8 +175,9 @@ export default function UsersPage() {
                             size="icon"
                             onClick={() => openEdit(u)}
                             title="수정"
+                            aria-label={`사용자 ${u.username} 수정`}
                           >
-                            <Pencil className="h-4 w-4" />
+                            <Pencil className="h-4 w-4" aria-hidden="true" />
                           </Button>
                           {u.id !== currentUser?.id && (
                             <Button
@@ -184,9 +185,10 @@ export default function UsersPage() {
                               size="icon"
                               onClick={() => setDeleteTarget(u)}
                               title="삭제"
+                              aria-label={`사용자 ${u.username} 삭제`}
                               className="text-destructive hover:text-destructive"
                             >
-                              <Trash2 className="h-4 w-4" />
+                              <Trash2 className="h-4 w-4" aria-hidden="true" />
                             </Button>
                           )}
                         </div>

--- a/frontend/src/app/settings/watcher/page.tsx
+++ b/frontend/src/app/settings/watcher/page.tsx
@@ -10,8 +10,8 @@ export default function WatcherSettingsPage() {
     <div className="space-y-6">
       <div className="flex items-center gap-3">
         <Button variant="ghost" size="icon" asChild>
-          <Link href="/settings">
-            <ArrowLeft className="h-4 w-4" />
+          <Link href="/settings" aria-label="설정 목록으로 돌아가기">
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
           </Link>
         </Button>
         <h2 className="text-2xl font-bold">디렉토리 감시 설정</h2>

--- a/frontend/src/components/documents/document-list.tsx
+++ b/frontend/src/components/documents/document-list.tsx
@@ -165,8 +165,11 @@ export function DocumentList() {
                   <TableCell className="text-right">
                     <div className="flex items-center justify-end gap-1">
                       <Button variant="ghost" size="icon" asChild>
-                        <Link href={`/documents/${doc.id}`}>
-                          <Eye className="h-4 w-4" />
+                        <Link
+                          href={`/documents/${doc.id}`}
+                          aria-label={`${doc.filename} 상세 보기`}
+                        >
+                          <Eye className="h-4 w-4" aria-hidden="true" />
                         </Link>
                       </Button>
                       <Button
@@ -174,15 +177,17 @@ export function DocumentList() {
                         size="icon"
                         onClick={() => handleReindex(doc.id)}
                         disabled={reindexMutation.isPending}
+                        aria-label={`${doc.filename} 재인덱싱`}
                       >
-                        <RefreshCw className="h-4 w-4" />
+                        <RefreshCw className="h-4 w-4" aria-hidden="true" />
                       </Button>
                       <Button
                         variant="ghost"
                         size="icon"
                         onClick={() => setDeleteId(doc.id)}
+                        aria-label={`${doc.filename} 삭제`}
                       >
-                        <Trash2 className="h-4 w-4" />
+                        <Trash2 className="h-4 w-4" aria-hidden="true" />
                       </Button>
                     </div>
                   </TableCell>

--- a/frontend/src/components/documents/document-upload.tsx
+++ b/frontend/src/components/documents/document-upload.tsx
@@ -64,7 +64,7 @@ export function DocumentUpload() {
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         <Button>
-          <Upload className="mr-2 h-4 w-4" />
+          <Upload className="mr-2 h-4 w-4" aria-hidden="true" />
           업로드
         </Button>
       </DialogTrigger>
@@ -80,20 +80,23 @@ export function DocumentUpload() {
             className={`flex flex-col items-center justify-center rounded-lg border-2 border-dashed p-8 transition-colors ${
               dragOver ? "border-primary bg-primary/5" : "border-muted-foreground/25"
             }`}
+            aria-label="파일 드롭 영역"
           >
-            <FileUp className="mb-2 h-8 w-8 text-muted-foreground" />
-            <p className="text-sm text-muted-foreground">
+            <FileUp className="mb-2 h-8 w-8 text-muted-foreground" aria-hidden="true" />
+            <label htmlFor="document-upload-file" className="text-sm text-muted-foreground">
               파일을 드래그하여 놓거나 클릭하여 선택
-            </p>
+            </label>
             <p className="mt-1 text-xs text-muted-foreground">
               PDF, DOCX, TXT, MD 지원
             </p>
             <input
+              id="document-upload-file"
               type="file"
               accept=".pdf,.docx,.txt,.md"
               className="absolute inset-0 cursor-pointer opacity-0"
               onChange={handleFileSelect}
               style={{ position: "relative", marginTop: "8px", width: "auto" }}
+              aria-label="업로드할 파일 선택"
             />
           </div>
           {selectedFile && (
@@ -108,13 +111,18 @@ export function DocumentUpload() {
                 variant="ghost"
                 size="icon"
                 onClick={() => setSelectedFile(null)}
+                aria-label={`선택된 파일 ${selectedFile.name} 제거`}
               >
-                <X className="h-4 w-4" />
+                <X className="h-4 w-4" aria-hidden="true" />
               </Button>
             </div>
           )}
           {uploadMutation.isPending && (
-            <Progress value={50} className="w-full" />
+            <Progress
+              value={50}
+              className="w-full"
+              aria-label="문서 업로드 진행률"
+            />
           )}
           <div className="flex justify-end gap-2">
             <Button variant="outline" onClick={() => setOpen(false)}>

--- a/frontend/src/components/layout/app-shell.tsx
+++ b/frontend/src/components/layout/app-shell.tsx
@@ -11,8 +11,20 @@ export function AppShell({ children }: { children: React.ReactNode }) {
 
   return (
     <div className="flex h-screen overflow-hidden">
+      {/* Skip-link for keyboard / screen reader users */}
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-primary focus:px-3 focus:py-2 focus:text-primary-foreground"
+      >
+        본문으로 건너뛰기
+      </a>
+
       {/* Desktop sidebar */}
-      <aside data-testid="sidebar" className="hidden w-60 shrink-0 border-r md:block">
+      <aside
+        data-testid="sidebar"
+        aria-label="사이드바"
+        className="hidden w-60 shrink-0 border-r md:block"
+      >
         <ScrollArea className="h-full">
           <Sidebar />
         </ScrollArea>
@@ -20,7 +32,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
 
       {/* Mobile sidebar */}
       <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
-        <SheetContent side="left" className="w-60 p-0">
+        <SheetContent side="left" className="w-60 p-0" aria-label="모바일 메뉴">
           <ScrollArea className="h-full">
             <Sidebar onNavigate={() => setMobileOpen(false)} />
           </ScrollArea>
@@ -30,7 +42,13 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       {/* Main content */}
       <div className="flex flex-1 flex-col overflow-hidden">
         <Header onMenuToggle={() => setMobileOpen(true)} />
-        <main className="flex-1 overflow-auto p-4 md:p-6">{children}</main>
+        <main
+          id="main-content"
+          tabIndex={-1}
+          className="flex-1 overflow-auto p-4 md:p-6 focus:outline-none"
+        >
+          {children}
+        </main>
       </div>
     </div>
   );

--- a/frontend/src/components/layout/header.tsx
+++ b/frontend/src/components/layout/header.tsx
@@ -53,24 +53,35 @@ export function Header({ onMenuToggle }: HeaderProps) {
           size="icon"
           className="md:hidden"
           onClick={onMenuToggle}
+          aria-label="메뉴 열기"
         >
-          <Menu className="h-5 w-5" />
+          <Menu className="h-5 w-5" aria-hidden="true" />
         </Button>
         <span className="text-sm font-medium md:hidden">UrstoryRAG</span>
       </div>
       <div className="flex items-center gap-4">
-        <div className="flex items-center gap-2">
+        <div
+          className="flex items-center gap-2"
+          role="status"
+          aria-live="polite"
+          aria-label={`시스템 상태: ${statusLabel}`}
+        >
           <span className="text-xs text-muted-foreground">시스템 상태</span>
           <Badge variant="outline" className="gap-1.5">
-            <span className={`h-2 w-2 rounded-full ${statusColor}`} />
+            <span className={`h-2 w-2 rounded-full ${statusColor}`} aria-hidden="true" />
             {statusLabel}
           </Badge>
         </div>
         {user && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="sm" className="gap-2">
-                <User className="h-4 w-4" />
+              <Button
+                variant="ghost"
+                size="sm"
+                className="gap-2"
+                aria-label={`사용자 메뉴: ${user.name}`}
+              >
+                <User className="h-4 w-4" aria-hidden="true" />
                 <span className="text-xs">
                   {user.name}
                 </span>
@@ -87,13 +98,13 @@ export function Header({ onMenuToggle }: HeaderProps) {
               <DropdownMenuSeparator />
               <DropdownMenuItem asChild>
                 <Link href="/settings/profile" className="cursor-pointer">
-                  <Settings className="mr-2 h-4 w-4" />
+                  <Settings className="mr-2 h-4 w-4" aria-hidden="true" />
                   프로필 설정
                 </Link>
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem onClick={handleLogout} className="cursor-pointer text-destructive">
-                <LogOut className="mr-2 h-4 w-4" />
+                <LogOut className="mr-2 h-4 w-4" aria-hidden="true" />
                 로그아웃
               </DropdownMenuItem>
             </DropdownMenuContent>

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -30,7 +30,7 @@ export function Sidebar({ onNavigate }: { onNavigate?: () => void }) {
   }
 
   return (
-    <nav className="flex flex-col gap-1 px-3 py-4">
+    <nav className="flex flex-col gap-1 px-3 py-4" aria-label="주 메뉴">
       <div className="mb-4 px-3">
         <h1 className="text-lg font-bold">UrstoryRAG</h1>
         <p className="text-xs text-muted-foreground">관리자 콘솔</p>
@@ -43,14 +43,16 @@ export function Sidebar({ onNavigate }: { onNavigate?: () => void }) {
             key={item.href}
             href={item.href}
             onClick={onNavigate}
+            aria-current={active ? "page" : undefined}
             className={cn(
               "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
               active
                 ? "bg-primary text-primary-foreground"
                 : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
             )}
           >
-            <Icon className="h-4 w-4" />
+            <Icon className="h-4 w-4" aria-hidden="true" />
             {item.label}
           </Link>
         );

--- a/frontend/src/components/search/search-input.tsx
+++ b/frontend/src/components/search/search-input.tsx
@@ -42,26 +42,39 @@ export function SearchInput({ onSearch, isLoading }: SearchInputProps) {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-4"
+      role="search"
+      aria-label="RAG 검색"
+    >
       <div className="flex gap-2">
+        <Label htmlFor="search-query" className="sr-only">
+          검색 쿼리
+        </Label>
         <Input
+          id="search-query"
           placeholder="검색 쿼리를 입력하세요..."
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           className="flex-1"
         />
         <Button type="submit" disabled={isLoading || !query.trim()}>
-          <Search className="mr-2 h-4 w-4" />
+          <Search className="mr-2 h-4 w-4" aria-hidden="true" />
           {isLoading ? "검색 중..." : "검색"}
         </Button>
       </div>
 
       {/* Search options */}
-      <div className="grid gap-4 rounded-md border p-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4">
+      <div
+        className="grid gap-4 rounded-md border p-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4"
+        role="group"
+        aria-label="검색 옵션"
+      >
         <div className="space-y-2">
-          <Label>검색 모드</Label>
+          <Label htmlFor="search-mode">검색 모드</Label>
           <Select value={searchMode} onValueChange={(v) => setSearchMode(v as typeof searchMode)}>
-            <SelectTrigger>
+            <SelectTrigger id="search-mode" aria-label="검색 모드 선택">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -74,23 +87,35 @@ export function SearchInput({ onSearch, isLoading }: SearchInputProps) {
         </div>
 
         <div className="flex items-center justify-between space-y-0 sm:flex-col sm:items-start sm:space-y-2">
-          <Label>HyDE</Label>
-          <Switch checked={useHyde} onCheckedChange={setUseHyde} />
+          <Label htmlFor="search-hyde">HyDE</Label>
+          <Switch
+            id="search-hyde"
+            checked={useHyde}
+            onCheckedChange={setUseHyde}
+            aria-label="HyDE 사용"
+          />
         </div>
 
         <div className="flex items-center justify-between space-y-0 sm:flex-col sm:items-start sm:space-y-2">
-          <Label>리랭킹</Label>
-          <Switch checked={useReranking} onCheckedChange={setUseReranking} />
+          <Label htmlFor="search-reranking">리랭킹</Label>
+          <Switch
+            id="search-reranking"
+            checked={useReranking}
+            onCheckedChange={setUseReranking}
+            aria-label="리랭킹 사용"
+          />
         </div>
 
         <div className="space-y-2">
-          <Label>Top-K: {topK}</Label>
+          <Label htmlFor="search-topk">Top-K: {topK}</Label>
           <Slider
+            id="search-topk"
             value={[topK]}
             onValueChange={(v) => setTopK(v[0])}
             min={1}
             max={20}
             step={1}
+            aria-label={`Top-K (현재 ${topK})`}
           />
         </div>
       </div>


### PR DESCRIPTION
Closes #20

## Summary
- `eslint-plugin-jsx-a11y` 설치 후 flat config에서 recommended 규칙 활성화 (CI에서 a11y 회귀 자동 차단)
- 아이콘 전용 버튼·링크 전반에 `aria-label`, 장식 아이콘엔 `aria-hidden="true"`
- 로그인/검색 폼에 `<Label htmlFor>`/`id` 연결, 에러에 `role="alert"` + `aria-live`
- 앱 셸에 Skip-link, `<main id tabIndex>`, 네비게이션 `aria-current="page"` 적용
- `global-error.tsx`의 `<html>`에 `lang="ko"` 추가 (린트 error 해결)

## Test plan
- [x] `pnpm lint` — 0 errors (기존 warning 13건은 본 PR과 무관한 React Hook Form/unused)
- [x] `pnpm type-check` — 통과
- [x] `pnpm build` — 성공
- [ ] 리뷰어: 키보드 Tab 이동, 포커스 링 확인
- [ ] 리뷰어: 스크린리더(VoiceOver)로 로그인/검색/사이드바 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)