### PR TITLE
feat(frontend): Error Boundary 및 통합 상태 컴포넌트 (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ UrstoryRAG는 **한국어에 최적화된 프로덕션 레벨 RAG(Retrieval-Augm
 | **Rate Limiting** | slowapi 기반 엔드포인트별 요청 제한 (로그인 5/min, 검색 30/min) |
 | **CORS 화이트리스트** | 환경변수 기반 허용 오리진 관리 (`allow_origins=["*"]` 제거) |
 | **접근성(a11y)** | ARIA 레이블/역할, 키보드 포커스 링, Skip-link, 에러 라이브 리전 적용. `eslint-plugin-jsx-a11y` 규칙으로 CI 자동 검증 |
+| **Error Boundary + 통합 상태 컴포넌트** | 글로벌/페이지/컴포넌트 3-tier Error Boundary, `LoadingState`/`EmptyState`/`ErrorState` 통합 컴포넌트. 401/403/404/429/5xx/네트워크 오류별 친절한 메시지와 재시도 |
 
 ---
 

--- a/frontend/src/app/documents/[id]/page.tsx
+++ b/frontend/src/app/documents/[id]/page.tsx
@@ -9,7 +9,8 @@ import { Separator } from "@/components/ui/separator";
 import { ChunkViewer } from "@/components/documents/chunk-viewer";
 import { IndexingStatus } from "@/components/documents/indexing-status";
 import { useDocument, useDocumentChunks, useReindexDocument } from "@/lib/queries";
-import { ArrowLeft, RefreshCw } from "lucide-react";
+import { LoadingState, ErrorState, EmptyState } from "@/components/error/state";
+import { ArrowLeft, RefreshCw, FileX } from "lucide-react";
 import { toast } from "sonner";
 
 export default function DocumentDetailPage({
@@ -18,7 +19,13 @@ export default function DocumentDetailPage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = use(params);
-  const { data: doc, isLoading: docLoading } = useDocument(id);
+  const {
+    data: doc,
+    isLoading: docLoading,
+    isError: docError,
+    error: docErrorObj,
+    refetch: refetchDoc,
+  } = useDocument(id);
   const { data: chunks, isLoading: chunksLoading } = useDocumentChunks(id);
   const reindexMutation = useReindexDocument();
 
@@ -37,12 +44,16 @@ export default function DocumentDetailPage({
     return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   };
 
-  if (docLoading) {
-    return <p className="text-muted-foreground">로딩 중...</p>;
-  }
-
+  if (docLoading) return <LoadingState label="문서를 불러오는 중..." />;
+  if (docError) return <ErrorState error={docErrorObj} retry={() => refetchDoc()} />;
   if (!doc) {
-    return <p className="text-muted-foreground">문서를 찾을 수 없습니다.</p>;
+    return (
+      <EmptyState
+        title="문서를 찾을 수 없습니다"
+        description="삭제되었거나 접근 권한이 없을 수 있습니다."
+        icon={<FileX className="h-8 w-8 text-muted-foreground" aria-hidden="true" />}
+      />
+    );
   }
 
   return (

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw, Home } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export default function RouteError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("RouteError:", error);
+  }, [error]);
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-8 text-center"
+    >
+      <AlertTriangle className="h-12 w-12 text-destructive" aria-hidden="true" />
+      <div className="space-y-2">
+        <h2 className="text-xl font-semibold">페이지를 불러오지 못했습니다</h2>
+        <p className="text-sm text-muted-foreground">
+          {error.message || "일시적인 오류일 수 있습니다. 잠시 후 다시 시도해 주세요."}
+        </p>
+      </div>
+      <div className="flex gap-2">
+        <Button onClick={reset} variant="default">
+          <RefreshCw className="mr-2 h-4 w-4" aria-hidden="true" />
+          다시 시도
+        </Button>
+        <Button asChild variant="outline">
+          <Link href="/">
+            <Home className="mr-2 h-4 w-4" aria-hidden="true" />
+            대시보드로
+          </Link>
+        </Button>
+      </div>
+      {error.digest && (
+        <p className="text-xs text-muted-foreground">
+          오류 코드: <code className="font-mono">{error.digest}</code>
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,23 @@
+import Link from "next/link";
+import { Home, FileQuestion } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-8 text-center">
+      <FileQuestion className="h-12 w-12 text-muted-foreground" aria-hidden="true" />
+      <div className="space-y-2">
+        <h2 className="text-xl font-semibold">페이지를 찾을 수 없습니다</h2>
+        <p className="text-sm text-muted-foreground">
+          요청하신 주소의 페이지가 존재하지 않거나 이동되었습니다.
+        </p>
+      </div>
+      <Button asChild>
+        <Link href="/">
+          <Home className="mr-2 h-4 w-4" aria-hidden="true" />
+          대시보드로
+        </Link>
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/components/error/api-error-fallback.tsx
+++ b/frontend/src/components/error/api-error-fallback.tsx
@@ -1,31 +1,12 @@
 "use client";
 
+import { ErrorState } from "./state";
+
 interface Props {
   error: Error;
   retry?: () => void;
 }
 
 export function ApiErrorFallback({ error, retry }: Props) {
-  const requestId = (error as unknown as Record<string, unknown>).requestId as string | undefined;
-
-  return (
-    <div className="rounded-lg border border-red-200 bg-red-50 p-6 text-center space-y-3">
-      <p className="font-medium text-red-800">
-        {error.message || "요청을 처리하지 못했습니다."}
-      </p>
-      {retry && (
-        <button
-          onClick={retry}
-          className="rounded-md bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-700"
-        >
-          다시 시도
-        </button>
-      )}
-      {requestId && (
-        <p className="text-xs text-red-400">
-          오류 코드: <code className="select-all">{requestId}</code>
-        </p>
-      )}
-    </div>
-  );
+  return <ErrorState error={error} retry={retry} />;
 }

--- a/frontend/src/components/error/error-boundary.tsx
+++ b/frontend/src/components/error/error-boundary.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import React from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  children: React.ReactNode;
+  fallback?: (error: Error, reset: () => void) => React.ReactNode;
+  onError?: (error: Error, info: React.ErrorInfo) => void;
+}
+
+interface State {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends React.Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error("ErrorBoundary caught:", error, info);
+    this.props.onError?.(error, info);
+  }
+
+  reset = () => this.setState({ error: null });
+
+  render() {
+    if (this.state.error) {
+      if (this.props.fallback) {
+        return this.props.fallback(this.state.error, this.reset);
+      }
+      return <ErrorBoundaryFallback error={this.state.error} reset={this.reset} />;
+    }
+    return this.props.children;
+  }
+}
+
+function ErrorBoundaryFallback({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className="flex min-h-[320px] flex-col items-center justify-center gap-4 rounded-lg border border-destructive/30 bg-destructive/5 p-8 text-center"
+    >
+      <AlertTriangle
+        className="h-10 w-10 text-destructive"
+        aria-hidden="true"
+      />
+      <div className="space-y-1">
+        <h3 className="text-lg font-semibold">화면을 표시하는 중 오류가 발생했습니다</h3>
+        <p className="text-sm text-muted-foreground">
+          {error.message || "알 수 없는 오류"}
+        </p>
+      </div>
+      <Button onClick={reset} variant="outline">
+        <RefreshCw className="mr-2 h-4 w-4" aria-hidden="true" />
+        다시 시도
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/components/error/state.tsx
+++ b/frontend/src/components/error/state.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { Loader2, AlertTriangle, Inbox, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ApiError } from "@/lib/api";
+
+interface LoadingStateProps {
+  label?: string;
+  className?: string;
+}
+
+export function LoadingState({ label = "불러오는 중...", className }: LoadingStateProps) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={
+        className ??
+        "flex min-h-[200px] flex-col items-center justify-center gap-3 text-muted-foreground"
+      }
+    >
+      <Loader2 className="h-6 w-6 animate-spin" aria-hidden="true" />
+      <span className="text-sm">{label}</span>
+    </div>
+  );
+}
+
+interface EmptyStateProps {
+  title?: string;
+  description?: string;
+  action?: React.ReactNode;
+  icon?: React.ReactNode;
+  className?: string;
+}
+
+export function EmptyState({
+  title = "데이터가 없습니다",
+  description,
+  action,
+  icon,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div
+      className={
+        className ??
+        "flex min-h-[200px] flex-col items-center justify-center gap-3 rounded-lg border border-dashed p-8 text-center"
+      }
+    >
+      {icon ?? <Inbox className="h-8 w-8 text-muted-foreground" aria-hidden="true" />}
+      <div className="space-y-1">
+        <h3 className="text-sm font-medium">{title}</h3>
+        {description && (
+          <p className="text-xs text-muted-foreground">{description}</p>
+        )}
+      </div>
+      {action}
+    </div>
+  );
+}
+
+interface ErrorStateProps {
+  error: unknown;
+  retry?: () => void;
+  className?: string;
+}
+
+interface FriendlyError {
+  title: string;
+  description: string;
+  actionLabel: string;
+}
+
+function describeError(error: unknown): FriendlyError {
+  if (error instanceof ApiError) {
+    switch (error.status) {
+      case 401:
+        return {
+          title: "로그인이 필요합니다",
+          description: "세션이 만료되었습니다. 다시 로그인해 주세요.",
+          actionLabel: "로그인 페이지로",
+        };
+      case 403:
+        return {
+          title: "접근 권한이 없습니다",
+          description: "이 작업을 수행할 권한이 없습니다. 관리자에게 문의하세요.",
+          actionLabel: "다시 시도",
+        };
+      case 404:
+        return {
+          title: "요청한 리소스를 찾을 수 없습니다",
+          description: error.message || "해당 항목이 삭제되었거나 이동되었을 수 있습니다.",
+          actionLabel: "다시 시도",
+        };
+      case 429:
+        return {
+          title: "요청이 너무 많습니다",
+          description: "잠시 후 다시 시도해 주세요.",
+          actionLabel: "다시 시도",
+        };
+      case 500:
+      case 502:
+      case 503:
+      case 504:
+        return {
+          title: "서버 오류가 발생했습니다",
+          description: "일시적인 문제일 수 있습니다. 잠시 후 다시 시도해 주세요.",
+          actionLabel: "다시 시도",
+        };
+      default:
+        return {
+          title: "요청을 처리하지 못했습니다",
+          description: error.message || "잠시 후 다시 시도해 주세요.",
+          actionLabel: "다시 시도",
+        };
+    }
+  }
+
+  // Native fetch errors (network offline, DNS, etc.) are TypeErrors like "Failed to fetch"
+  if (error instanceof TypeError && /fetch/i.test(error.message)) {
+    return {
+      title: "서버에 연결할 수 없습니다",
+      description: "네트워크 연결을 확인한 뒤 다시 시도해 주세요.",
+      actionLabel: "다시 시도",
+    };
+  }
+
+  if (error instanceof Error) {
+    return {
+      title: "오류가 발생했습니다",
+      description: error.message,
+      actionLabel: "다시 시도",
+    };
+  }
+
+  return {
+    title: "오류가 발생했습니다",
+    description: "알 수 없는 오류입니다.",
+    actionLabel: "다시 시도",
+  };
+}
+
+export function ErrorState({ error, retry, className }: ErrorStateProps) {
+  const { title, description, actionLabel } = describeError(error);
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className={
+        className ??
+        "flex min-h-[200px] flex-col items-center justify-center gap-3 rounded-lg border border-destructive/30 bg-destructive/5 p-6 text-center"
+      }
+    >
+      <AlertTriangle className="h-8 w-8 text-destructive" aria-hidden="true" />
+      <div className="space-y-1">
+        <h3 className="text-sm font-semibold">{title}</h3>
+        <p className="text-xs text-muted-foreground">{description}</p>
+      </div>
+      {retry && (
+        <Button onClick={retry} variant="outline" size="sm">
+          <RefreshCw className="mr-2 h-4 w-4" aria-hidden="true" />
+          {actionLabel}
+        </Button>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Pick the correct state component for a TanStack Query-style result.
+ * Use when a page/section follows the simple (isLoading / isError / data) pattern.
+ */
+interface QueryStateProps<T> {
+  isLoading: boolean;
+  isError: boolean;
+  error: unknown;
+  data: T | undefined;
+  retry?: () => void;
+  empty?: EmptyStateProps;
+  children: (data: T) => React.ReactNode;
+}
+
+export function QueryState<T>({
+  isLoading,
+  isError,
+  error,
+  data,
+  retry,
+  empty,
+  children,
+}: QueryStateProps<T>) {
+  if (isLoading) return <LoadingState />;
+  if (isError) return <ErrorState error={error} retry={retry} />;
+  if (!data || (Array.isArray(data) && data.length === 0)) {
+    return <EmptyState {...(empty ?? {})} />;
+  }
+  return <>{children(data)}</>;
+}

--- a/frontend/src/components/layout/app-shell.tsx
+++ b/frontend/src/components/layout/app-shell.tsx
@@ -5,6 +5,7 @@ import { Sidebar } from "./sidebar";
 import { Header } from "./header";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { ErrorBoundary } from "@/components/error/error-boundary";
 
 export function AppShell({ children }: { children: React.ReactNode }) {
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -47,7 +48,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
           tabIndex={-1}
           className="flex-1 overflow-auto p-4 md:p-6 focus:outline-none"
         >
-          {children}
+          <ErrorBoundary>{children}</ErrorBoundary>
         </main>
       </div>
     </div>

--- a/frontend/src/components/settings/chunking-form.tsx
+++ b/frontend/src/components/settings/chunking-form.tsx
@@ -15,6 +15,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useSettings, useUpdateSettings } from "@/lib/queries";
+import { LoadingState, ErrorState } from "@/components/error/state";
 import { toast } from "sonner";
 import { Save } from "lucide-react";
 
@@ -27,7 +28,7 @@ const chunkingSchema = z.object({
 type ChunkingFormData = z.infer<typeof chunkingSchema>;
 
 export function ChunkingForm() {
-  const { data: settings, isLoading, isError } = useSettings();
+  const { data: settings, isLoading, isError, error } = useSettings();
   const updateMutation = useUpdateSettings();
 
   const form = useForm<ChunkingFormData>({
@@ -52,8 +53,8 @@ export function ChunkingForm() {
     }
   };
 
-  if (isLoading) return <p className="text-muted-foreground">로딩 중...</p>;
-  if (isError) return <p className="text-destructive">설정을 불러올 수 없습니다.</p>;
+  if (isLoading) return <LoadingState />;
+  if (isError) return <ErrorState error={error} />;
 
   const chunkSize = form.watch("chunk_size");
   const chunkOverlap = form.watch("chunk_overlap");

--- a/frontend/src/components/settings/embedding-form.tsx
+++ b/frontend/src/components/settings/embedding-form.tsx
@@ -15,6 +15,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useSettings, useUpdateSettings } from "@/lib/queries";
+import { LoadingState, ErrorState } from "@/components/error/state";
 import { toast } from "sonner";
 import { Save } from "lucide-react";
 
@@ -26,7 +27,7 @@ const embeddingSchema = z.object({
 type EmbeddingFormData = z.infer<typeof embeddingSchema>;
 
 export function EmbeddingForm() {
-  const { data: settings, isLoading, isError } = useSettings();
+  const { data: settings, isLoading, isError, error } = useSettings();
   const updateMutation = useUpdateSettings();
 
   const form = useForm<EmbeddingFormData>({
@@ -49,8 +50,8 @@ export function EmbeddingForm() {
     }
   };
 
-  if (isLoading) return <p className="text-muted-foreground">로딩 중...</p>;
-  if (isError) return <p className="text-destructive">설정을 불러올 수 없습니다.</p>;
+  if (isLoading) return <LoadingState />;
+  if (isError) return <ErrorState error={error} />;
 
   return (
     <Card>

--- a/frontend/src/components/settings/generation-form.tsx
+++ b/frontend/src/components/settings/generation-form.tsx
@@ -16,6 +16,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useSettings, useUpdateSettings } from "@/lib/queries";
+import { LoadingState, ErrorState } from "@/components/error/state";
 import { toast } from "sonner";
 import { Save } from "lucide-react";
 
@@ -28,7 +29,7 @@ const generationSchema = z.object({
 type GenerationFormData = z.infer<typeof generationSchema>;
 
 export function GenerationForm() {
-  const { data: settings, isLoading, isError } = useSettings();
+  const { data: settings, isLoading, isError, error } = useSettings();
   const updateMutation = useUpdateSettings();
 
   const form = useForm<GenerationFormData>({
@@ -53,8 +54,8 @@ export function GenerationForm() {
     }
   };
 
-  if (isLoading) return <p className="text-muted-foreground">로딩 중...</p>;
-  if (isError) return <p className="text-destructive">설정을 불러올 수 없습니다.</p>;
+  if (isLoading) return <LoadingState />;
+  if (isError) return <ErrorState error={error} />;
 
   return (
     <Card>

--- a/frontend/src/components/settings/guardrails-form.tsx
+++ b/frontend/src/components/settings/guardrails-form.tsx
@@ -9,6 +9,7 @@ import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Separator } from "@/components/ui/separator";
 import { useSettings, useUpdateSettings } from "@/lib/queries";
+import { LoadingState, ErrorState } from "@/components/error/state";
 import { toast } from "sonner";
 import { Save } from "lucide-react";
 
@@ -23,7 +24,7 @@ const guardrailsSchema = z.object({
 type GuardrailsFormData = z.infer<typeof guardrailsSchema>;
 
 export function GuardrailsForm() {
-  const { data: settings, isLoading, isError } = useSettings();
+  const { data: settings, isLoading, isError, error } = useSettings();
   const updateMutation = useUpdateSettings();
 
   const form = useForm<GuardrailsFormData>({
@@ -52,8 +53,8 @@ export function GuardrailsForm() {
     }
   };
 
-  if (isLoading) return <p className="text-muted-foreground">로딩 중...</p>;
-  if (isError) return <p className="text-destructive">설정을 불러올 수 없습니다.</p>;
+  if (isLoading) return <LoadingState />;
+  if (isError) return <ErrorState error={error} />;
 
   return (
     <Card>

--- a/frontend/src/components/settings/hyde-form.tsx
+++ b/frontend/src/components/settings/hyde-form.tsx
@@ -9,6 +9,7 @@ import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { useSettings, useUpdateSettings } from "@/lib/queries";
+import { LoadingState, ErrorState } from "@/components/error/state";
 import { toast } from "sonner";
 import { Save } from "lucide-react";
 
@@ -20,7 +21,7 @@ const hydeSchema = z.object({
 type HyDEFormData = z.infer<typeof hydeSchema>;
 
 export function HyDEForm() {
-  const { data: settings, isLoading, isError } = useSettings();
+  const { data: settings, isLoading, isError, error } = useSettings();
   const updateMutation = useUpdateSettings();
 
   const form = useForm<HyDEFormData>({
@@ -43,8 +44,8 @@ export function HyDEForm() {
     }
   };
 
-  if (isLoading) return <p className="text-muted-foreground">로딩 중...</p>;
-  if (isError) return <p className="text-destructive">설정을 불러올 수 없습니다.</p>;
+  if (isLoading) return <LoadingState />;
+  if (isError) return <ErrorState error={error} />;
 
   return (
     <Card>

--- a/frontend/src/components/settings/reranking-form.tsx
+++ b/frontend/src/components/settings/reranking-form.tsx
@@ -9,6 +9,7 @@ import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { useSettings, useUpdateSettings } from "@/lib/queries";
+import { LoadingState, ErrorState } from "@/components/error/state";
 import { toast } from "sonner";
 import { Save } from "lucide-react";
 
@@ -22,7 +23,7 @@ const rerankingSchema = z.object({
 type RerankingFormData = z.infer<typeof rerankingSchema>;
 
 export function RerankingForm() {
-  const { data: settings, isLoading, isError } = useSettings();
+  const { data: settings, isLoading, isError, error } = useSettings();
   const updateMutation = useUpdateSettings();
 
   const form = useForm<RerankingFormData>({
@@ -49,8 +50,8 @@ export function RerankingForm() {
     }
   };
 
-  if (isLoading) return <p className="text-muted-foreground">로딩 중...</p>;
-  if (isError) return <p className="text-destructive">설정을 불러올 수 없습니다.</p>;
+  if (isLoading) return <LoadingState />;
+  if (isError) return <ErrorState error={error} />;
 
   return (
     <Card>

--- a/frontend/src/components/settings/search-form.tsx
+++ b/frontend/src/components/settings/search-form.tsx
@@ -17,6 +17,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useSettings, useUpdateSettings } from "@/lib/queries";
+import { LoadingState, ErrorState } from "@/components/error/state";
 import { toast } from "sonner";
 import { Save } from "lucide-react";
 
@@ -40,7 +41,7 @@ const searchSchema = z.object({
 type SearchFormData = z.infer<typeof searchSchema>;
 
 export function SearchForm() {
-  const { data: settings, isLoading, isError } = useSettings();
+  const { data: settings, isLoading, isError, error } = useSettings();
   const updateMutation = useUpdateSettings();
 
   const form = useForm<SearchFormData>({
@@ -87,8 +88,8 @@ export function SearchForm() {
     }
   };
 
-  if (isLoading) return <p className="text-muted-foreground">로딩 중...</p>;
-  if (isError) return <p className="text-destructive">설정을 불러올 수 없습니다.</p>;
+  if (isLoading) return <LoadingState />;
+  if (isError) return <ErrorState error={error} />;
 
   const mode = form.watch("mode");
   const vectorWeight = form.watch("vector_weight");

--- a/frontend/src/components/settings/watcher-form.tsx
+++ b/frontend/src/components/settings/watcher-form.tsx
@@ -26,6 +26,7 @@ import {
   useStopWatcher,
   useScanWatcher,
 } from "@/lib/queries";
+import { LoadingState, ErrorState } from "@/components/error/state";
 import type { RAGSettings } from "@/types";
 import { toast } from "sonner";
 import { Save, Plus, Trash2, Play, Square, RefreshCw } from "lucide-react";
@@ -42,7 +43,7 @@ const watcherSchema = z.object({
 type WatcherFormData = z.infer<typeof watcherSchema>;
 
 export function WatcherForm() {
-  const { data: settings, isLoading, isError } = useSettings();
+  const { data: settings, isLoading, isError, error } = useSettings();
   const updateMutation = useUpdateSettings();
   const { data: watcherStatus } = useWatcherStatus();
   const startMutation = useStartWatcher();
@@ -97,8 +98,8 @@ export function WatcherForm() {
     }
   };
 
-  if (isLoading) return <p className="text-muted-foreground">로딩 중...</p>;
-  if (isError) return <p className="text-destructive">설정을 불러올 수 없습니다.</p>;
+  if (isLoading) return <LoadingState />;
+  if (isError) return <ErrorState error={error} />;
 
   const usePolling = form.watch("use_polling");
   const pollingInterval = form.watch("polling_interval");


### PR DESCRIPTION
Closes #17

## Summary
- 글로벌(`global-error.tsx`) → 라우트(`app/error.tsx`) → 컴포넌트(`ErrorBoundary`) 3단 에러 경계 구성
- 통합 상태 컴포넌트 `LoadingState`/`EmptyState`/`ErrorState` (`components/error/state.tsx`)
- `ApiError.status`별 친절한 메시지 매핑 (401/403/404/429/5xx/네트워크)
- 8개 settings 폼이 통합 상태 컴포넌트로 일관된 UX 제공
- 문서 상세 페이지에 `LoadingState`/`EmptyState`/`ErrorState` 적용

## Test plan
- [x] `pnpm type-check` — 통과
- [x] `pnpm lint` — 0 errors
- [x] `pnpm build` — 성공
- [ ] 리뷰어: 백엔드 다운 상태에서 페이지 접근 시 ErrorState 표시 확인
- [ ] 리뷰어: 잘못된 URL `/foo` 접근 시 not-found 페이지 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)