### PR TITLE
fix(ci): pip-audit --strict에 --skip-editable 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,9 @@ jobs:
       - name: Security audit (pip-audit)
         run: |
           pip install pip-audit
-          pip-audit --strict --desc
+          # --skip-editable: 프로젝트 자체(urstory-rag, editable 설치)는 PyPI에
+          # 없으므로 --strict 조합에서 audit 실패를 유발한다. 의존성만 검사한다.
+          pip-audit --strict --desc --skip-editable
 
   frontend-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
모든 dependabot PR의 backend-test가 `pip-audit` 단계에서 실패하는 원인 수정.

에러:
\`\`\`
ERROR:pip_audit._cli:urstory-rag: Dependency not found on PyPI and could not be audited: urstory-rag (0.1.0)
\`\`\`

## 원인
CI는 `pip install -e ".[dev]"`로 프로젝트를 **editable 설치**한다. pip-audit은
설치된 모든 패키지를 대상으로 하므로 프로젝트 자체(`urstory-rag==0.1.0`)까지 audit 시도하는데,
PyPI에 올라가 있지 않아 `--strict` 조합에서 치명적 실패를 유발한다.

## 수정
`--skip-editable` 플래그 추가. 의존성/전이 의존성은 그대로 감사된다.

## Test plan
- [x] CI 실행 → 이 PR 포함 5개 dependabot PR rebase 후 backend-test 통과 확인