### PR TITLE
deps(frontend): bump @types/node from 24.12.3 to 24.12.4

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.0",
-    "@types/node": "^24.12.3",
+    "@types/node": "^24.12.4",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -58,7 +58,7 @@ importers:
         specifier: ^4.3.0
         version: 4.3.0
       '@types/node':
-        specifier: ^24.12.3
+        specifier: ^24.12.4
         version: 24.12.4
       '@types/react':
         specifier: ^19


### PR DESCRIPTION
dependabot PR #100 적용.

#101 통합 업데이트에서 `@types/node` 24.12.4가 이미 `pnpm-lock.yaml`에 해석되어 들어갔고, 본 PR은 `package.json`의 caret 범위를 `^24.12.4`로 맞춘다.

- `@types/node` `^24.12.3` → `^24.12.4`

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)